### PR TITLE
Add Netlify identity widget on Admin

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v1
-      - uses: cypress-io/github-action@v1
+      - uses: cypress-io/github-action@v2
         with:
           browser: chrome
           headless: true
           build: yarn build
           start: yarn serve
         env:
-          CI: true
+          CYPRESS_CI: true

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -12,7 +12,7 @@ const { initializeEcommerce } = require('./src/utils/ga');
 
 // You can delete this file if you're not using it
 exports.onClientEntry = () => {
-  if (process.env.NODE_ENV === 'development' || process.env.CI) {
+  if (process.env.NODE_ENV === 'development' || process.env.CI === 'true') {
     return;
   }
 
@@ -20,7 +20,7 @@ exports.onClientEntry = () => {
     dsn: 'https://7fd6de81b2484ea18e6392ddd131ddb4@sentry.io/5170131',
     // Optional settings, see https://docs.sentry.io/clients/node/config/#optional-settings
     environment: process.env.NODE_ENV,
-    enabled: process.env.NODE_ENV === 'production' && !process.env.CI,
+    enabled: process.env.NODE_ENV === 'production' && process.env.CI !== 'true',
     release: `infire@${process.env.BUILD_ID}`,
     integrations: [
       new CaptureConsole({

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -118,7 +118,6 @@ module.exports = {
       resolve: 'gatsby-plugin-netlify-cms',
       options: {
         modulePath: `${__dirname}/src/cms/cms.js`,
-        enableIdentityWidget: false,
       },
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 
-const getAnalytics = () => process.env.CI ? [] : [{
+const getAnalytics = () => process.env.CI === 'true' ? [] : [{
   resolve: 'gatsby-plugin-google-analytics',
   options: {
     trackingId: 'UA-158091113-1',

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,16 @@
 const path = require('path');
 const { createFilePath } = require('gatsby-source-filesystem');
+const webpack = require('webpack');
+
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    plugins: [
+      new webpack.IgnorePlugin({
+        resourceRegExp: /^netlify-identity-widget$/,
+      }),
+    ],
+  });
+};
 
 /**
  * Implement Gatsby's Node APIs in this file.

--- a/static/emails/recovery.html
+++ b/static/emails/recovery.html
@@ -1,0 +1,4 @@
+<h2>Resetar a senha</h2>
+
+<p>Siga o link para resetar a senha do seu usuário:</p>
+<p><a href="{{ .ConfirmationURL }}/admin">Resetar Senha</a></p>


### PR DESCRIPTION
Enables password recovery from Netlify identity without adding weight to the root page.

Refer to https://github.com/gatsbyjs/gatsby/issues/21086#issuecomment-581405027